### PR TITLE
Move to Common package, Re-instate Serilog

### DIFF
--- a/Sessions/App.config
+++ b/Sessions/App.config
@@ -14,6 +14,8 @@
     </DbProviderFactories>
   </system.data>
   <appSettings>
+    <add key="serilog:minimum-level" value="Debug" />
+    <add key="serilog:write-to:ColoredConsole" />
     <add key="BaseUrl" value="http://*:8080" />
   </appSettings>
 </configuration>

--- a/Sessions/Logging.fs
+++ b/Sessions/Logging.fs
@@ -1,0 +1,7 @@
+﻿module Logging
+
+open Serilog
+
+let initialize() =
+    Log.Logger <- LoggerConfiguration().ReadFrom.AppSettings().CreateLogger()
+    Log.Logger.Information("Serilog logging initialised")

--- a/Sessions/Program.fs
+++ b/Sessions/Program.fs
@@ -4,6 +4,8 @@ open Microsoft.Owin.Hosting
 open System
 open System.Configuration
 open System.Threading
+open Serilog
+open Startup
 
 (*
     Do not run Visual Studio as Administrator!
@@ -18,12 +20,14 @@ let main _ =
         if String.IsNullOrEmpty baseUrl then
             failwith "Missing configuration value: 'BaseUrl'"
 
-        use server = WebApp.Start<Bristech.Srm.HttpConfig.Startup>(baseUrl)
-        printfn "Listening on %s" baseUrl
+        use server = WebApp.Start<Startup>(baseUrl)
+        Log.Information ("Listening on {0}", baseUrl)
 
         let waitIndefinitelyWithToken = 
             let cancelSource = new CancellationTokenSource()
             cancelSource.Token.WaitHandle.WaitOne() |> ignore
         0
     with
-    | ex -> 1
+    | ex -> 
+      Log.Fatal ("Exception: {0}", ex)
+      1

--- a/Sessions/Sessions.fsproj
+++ b/Sessions/Sessions.fsproj
@@ -63,14 +63,15 @@
     <Compile Include="HandlesController.fs" />
     <Compile Include="ProfilesController.fs" />
     <Compile Include="SessionsController.fs" />
+    <Compile Include="Logging.fs" />
+    <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
     <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Bristech.Srm.HttpConfig">
-      <HintPath>..\packages\Bristech.Srm.HttpConfig.0.1.4\lib\net45\Bristech.Srm.HttpConfig.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Bristech.Srm.Common">
+      <HintPath>..\packages\Bristech.Srm.Common.0.1.0\lib\net45\Bristech.Srm.Common.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>

--- a/Sessions/Startup.fs
+++ b/Sessions/Startup.fs
@@ -1,0 +1,19 @@
+﻿module Startup
+
+open Common
+open Logging
+open Owin
+open System.Web.Http
+
+type Startup() =
+  member __.Configuration (appBuilder: IAppBuilder) =
+    Logging.initialize()
+
+    let config =
+      new HttpConfiguration()
+      |> Logging.configure
+      |> Cors.configure
+      |> Routes.configure
+      |> Serialization.configure
+
+    appBuilder.UseWebApi(config) |> ignore

--- a/Sessions/packages.config
+++ b/Sessions/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bristech.Srm.HttpConfig" version="0.1.4" targetFramework="net45" />
+  <package id="Bristech.Srm.Common" version="0.1.0" targetFramework="net45" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
The rewrite missed the migration from our HttpConfig to new Common nuget package, and lost the Serilog logging.  This just puts them back in, for that familiar microservice startup "look".