### PR TITLE
Log http, log exceptions

### DIFF
--- a/Sessions/LogExceptionHandler.fs
+++ b/Sessions/LogExceptionHandler.fs
@@ -1,0 +1,16 @@
+﻿module LogExceptionHandler
+
+open Serilog
+open System
+open System.Net
+open System.Web.Http.ExceptionHandling
+
+type LogExceptionHandler =
+  inherit ExceptionHandler
+
+  new () =
+    {}
+
+  override this.Handle (context: ExceptionHandlerContext) =
+    Log.Error("Exception: {0}", context.Exception)
+    base.Handle(context)

--- a/Sessions/LogHttpMiddleware.fs
+++ b/Sessions/LogHttpMiddleware.fs
@@ -1,0 +1,25 @@
+﻿module LogHttpMiddleware
+
+open Serilog
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+open System.Web.Http
+
+let awaitTask = Async.AwaitIAsyncResult >> Async.Ignore 
+
+type LogHttpMiddleware(next: Func<IDictionary<string,obj>, Task>) =
+
+  member this.Invoke (environment: IDictionary<string,obj>) : Task =
+    async {
+
+      let verb = environment.Item("owin.RequestMethod").ToString()
+      let path = environment.Item("owin.RequestPath").ToString()
+
+      do!
+        awaitTask <| next.Invoke environment
+
+      let code = environment.Item("owin.ResponseStatusCode").ToString()
+      Log.Information ("{0} {1} {2}", verb, path, code)
+
+    } |> Async.StartAsTask :> Task

--- a/Sessions/Sessions.fsproj
+++ b/Sessions/Sessions.fsproj
@@ -63,6 +63,8 @@
     <Compile Include="HandlesController.fs" />
     <Compile Include="ProfilesController.fs" />
     <Compile Include="SessionsController.fs" />
+    <Compile Include="LogHttpMiddleware.fs" />
+    <Compile Include="LogExceptionHandler.fs" />
     <Compile Include="Logging.fs" />
     <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />

--- a/Sessions/Startup.fs
+++ b/Sessions/Startup.fs
@@ -2,12 +2,17 @@
 
 open Common
 open Logging
+open LogHttpMiddleware
+open LogExceptionHandler
 open Owin
 open System.Web.Http
+open System.Web.Http.ExceptionHandling
 
 type Startup() =
   member __.Configuration (appBuilder: IAppBuilder) =
     Logging.initialize()
+
+    appBuilder.Use LogHttpMiddleware |> ignore
 
     let config =
       new HttpConfiguration()
@@ -15,5 +20,7 @@ type Startup() =
       |> Cors.configure
       |> Routes.configure
       |> Serialization.configure
+
+    config.Services.Replace(typedefof<IExceptionHandler>, new LogExceptionHandler())
 
     appBuilder.UseWebApi(config) |> ignore


### PR DESCRIPTION
Now we have logging...
Install Owin middleware to log the request and response code.
Install a WebApi 2 ExceptionHandler to capture uncaught exceptions.

And we're ready to go.